### PR TITLE
Fix/bf256

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "projecthealth-frontend",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "private": true,
   "dependencies": {
     "@date-io/date-fns": "^2.13.1",

--- a/src/components/post-login/Onboarding1.js
+++ b/src/components/post-login/Onboarding1.js
@@ -99,7 +99,11 @@ const Onboarding1 = () => {
 
   // Handle Switch changes
   const handleChange = (event) => {
-    setIsChecked(!isChecked);
+    if (Notification.permission === "granted") {
+      setIsChecked(true);
+    } else {
+      setIsChecked(false);
+    }
     setNotifIsAllowed(false);
   }
 


### PR DESCRIPTION
BF256: User should be redirected to disclaimer page instead of notification time setting when they choose to not enable notifications during initial login in device